### PR TITLE
DaggerHiltの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@
 ## Libraries
 
 - Retrofit
+- Dagger Hilt

--- a/SongFinder/app/build.gradle
+++ b/SongFinder/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.dagger.hilt.android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -66,4 +68,12 @@ dependencies {
 
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+
+    // Dagger Hilt
+    implementation 'com.google.dagger:hilt-android:2.46.1'
+    kapt 'com.google.dagger:hilt-compiler:2.46.1'
+}
+
+kapt {
+    correctErrorTypes true
 }

--- a/SongFinder/build.gradle
+++ b/SongFinder/build.gradle
@@ -3,4 +3,6 @@ plugins {
     id 'com.android.application' version '8.0.2' apply false
     id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'com.google.dagger.hilt.android' version '2.46.1' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.8.22'
 }


### PR DESCRIPTION
- https://dagger.dev/hilt/gradle-setup
- https://kotlinlang.org/docs/kapt.html

## 備考

- KaptからKSPへ移行するよう記載があるがDaggerHiltがKSPに移行していないようなのでKaptを利用
  - https://medium.com/@callmeryan/migrate-from-kapt-to-kotlin-ksp-not-the-best-time-yet-b30f8869da17